### PR TITLE
Clarify that installing needs `cf install-plugin`

### DIFF
--- a/autoscaler/using-autoscaler-cli.html.md.erb
+++ b/autoscaler/using-autoscaler-cli.html.md.erb
@@ -13,7 +13,9 @@ To use the App Autoscaler CLI, you must first [install](#install) the App Autosc
 
 Before you can run App Autoscaler CLI commands on your local machine, you must install the App Autoscaler CLI plugin.
 
-To install the App Autoscaler CLI plugin, download it from <a href="https://network.pivotal.io/products/pcf-app-autoscaler">Pivotal Network</a>.
+First, download it from <a href="https://network.pivotal.io/products/pcf-app-autoscaler">Pivotal Network</a>.
+
+Then, [install the CLI plugin](https://docs.cloudfoundry.org/cf-cli/use-cli-plugins.html#plugin-install) by using `cf install-plugin ...` with the location of the downloaded plugin.
 
 <p class='note'><strong>NOTE:</strong> Ensure that you download the 2.0 release of the App Autoscaler CLI plugin. The App Autoscaler CLI is dependent on Pivotal Application Service 2.2</a>.</p> 
 


### PR DESCRIPTION
The installation directions don't actually tell you how to install a CF plugin, which is confusing if you haven't done it before.