### PR TITLE
Direct autoscaler users to Metric Registrar over Metrics Forwarder

### DIFF
--- a/autoscaler/using-autoscaler.html.md.erb
+++ b/autoscaler/using-autoscaler.html.md.erb
@@ -118,7 +118,7 @@ The table below lists the metrics that you can base App Autoscaler rules on:
 	</tr>
 	<tr>
 		<td>Custom</td>
-		<td>Users can configure their apps to emit custom metrics out of the <a href="https://docs.pivotal.io/pivotalcf/loggregator/architecture.html#firehose">Loggregator Firehose</a>. For steps on how to set up your apps to emit custom metrics, refer to the <a href="https://docs.pivotal.io/pivotalcf/2-5/metric-registrar/using.html">Registering Custom App Metrics</a> with Metric Registrar.</td>
+		<td>Users can configure their apps to emit custom metrics out of the <a href="https://docs.pivotal.io/pivotalcf/loggregator/architecture.html#firehose">Loggregator Firehose</a>. For steps on how to set up your apps to emit custom metrics, see <a href="https://docs.pivotal.io/pivotalcf/2-5/metric-registrar/using.html">Registering Custom App Metrics</a> with Metric Registrar.</td>
 	</tr>
 	<tr>
 		<td>Compare</td>

--- a/autoscaler/using-autoscaler.html.md.erb
+++ b/autoscaler/using-autoscaler.html.md.erb
@@ -118,7 +118,7 @@ The table below lists the metrics that you can base App Autoscaler rules on:
 	</tr>
 	<tr>
 		<td>Custom</td>
-		<td>Users can configure their apps to emit custom metrics out of the <a href="https://docs.pivotal.io/pivotalcf/loggregator/architecture.html#firehose">Loggregator Firehose</a>. For steps on how to set up your apps to emit custom metrics, refer to the <a href="https://docs.pivotal.io/metrics-forwarder/index.html">Metrics Forwarder Documentation</a>.</td>
+		<td>Users can configure their apps to emit custom metrics out of the <a href="https://docs.pivotal.io/pivotalcf/loggregator/architecture.html#firehose">Loggregator Firehose</a>. For steps on how to set up your apps to emit custom metrics, refer to the <a href="https://docs.pivotal.io/pivotalcf/2-5/metric-registrar/using.html">Registering Custom App Metrics</a> with Metric Registrar.</td>
 	</tr>
 	<tr>
 		<td>Compare</td>


### PR DESCRIPTION
App Autoscaler users who wish to scale their apps using custom metrics should do so with Metric Registrar instead of Metrics Forwarder as Metrics Forwarder is going out of support.