### PR TITLE
Clarification on a couple of points.

### DIFF
--- a/autoscaler/using-autoscaler.html.md.erb
+++ b/autoscaler/using-autoscaler.html.md.erb
@@ -30,9 +30,9 @@ The following diagram shows the components and architecture of App Autoscaler. I
 
 [View a larger version of this image.](./images/app-autoscaler-architecture.png)
 
-As demonstrated in the architecture diagram above, App Autoscaler makes scaling decisions based on custom scaling rules that users configure through the Cloud Foundry Command Line Interface (cf CLI) or through Apps Manager. 
+As demonstrated in the architecture diagram above, App Autoscaler makes scaling decisions based on auto-scaling rules that users configure through either the Cloud Foundry Command Line Interface (cf CLI) or through Apps Manager. The Autoscale API stores these auto-scaling rules in a MySQL database. 
 
-The Autoscale API stores these custom scaling rules in a MySQL database. The App Autoscaler app reads the scaling rules and retrieves app metric data from the Loggregator Log Cache. Then, App Autoscaler makes a scaling decision and communicates with the Cloud Controller to scale the app, if necessary.
+At a predefined interval, known as the scaling interval, the App Autoscaler app reads the scaling rules and retrieves app metric data from the Loggregator Log Cache. Then, App Autoscaler makes a scaling decision and communicates with the Cloud Controller to scale the app, if necessary.
 
 For more information about Loggregator Log Cache, see [Loggregator Architecture](../../loggregator/architecture.html). For more information about the Cloud Controller, see [Cloud Controller](../../concepts/architecture/cloud-controller.html).
 


### PR DESCRIPTION
Blocked the text a little more into "the pieces" and "the interactions" as paragraph 1 and 2 respectively. 

I'm not happy with the way the line "At a predefined interval, known as the scaling interval, the App Autoscaler app ..." reads, but I can't think of anything better. The rub is that the audience for this doesn't necessarily have any control over the scaling interval (that's a more operations-level thing) but might benefit from knowing that it's on a consistent cycle. Feel free to edit if something better comes to mind.