### PR TITLE
clarify units on latency metrics

### DIFF
--- a/autoscaler/using-autoscaler.html.md.erb
+++ b/autoscaler/using-autoscaler.html.md.erb
@@ -124,7 +124,7 @@ The table below lists the metrics that you can base App Autoscaler rules on:
 		<td>Total HTTP requests per second (divided by the total number of app instances).</td>
 	</tr><tr>
 		<td>HTTP Latency</td>
-		<td>Average latency of apps response to HTTP requests. This does not include Gorouter processing time or other network latency.<br>
+		<td>Average latency of the app's response to HTTP requests in ms. This does not include Gorouter processing time or other network latency.<br>
 		Average is calculated on the middle 99% or middle 95% of all HTTP requests.</td>
 	</tr><tr>
 		<td>RabbitMQ Depth</td>

--- a/autoscaler/using-autoscaler.html.md.erb
+++ b/autoscaler/using-autoscaler.html.md.erb
@@ -124,7 +124,7 @@ The table below lists the metrics that you can base App Autoscaler rules on:
 		<td>Total HTTP requests per second (divided by the total number of app instances).</td>
 	</tr><tr>
 		<td>HTTP Latency</td>
-		<td>Average latency of the app's response to HTTP requests in ms. This does not include Gorouter processing time or other network latency.<br>
+		<td>Average latency of the app response to HTTP requests in milliseconds. This does not include Gorouter processing time or other network latency.<br>
 		Average is calculated on the middle 99% or middle 95% of all HTTP requests.</td>
 	</tr><tr>
 		<td>RabbitMQ Depth</td>


### PR DESCRIPTION
Added an apostrophe and the unit to clarify how latency metrics are calculated. 

This change should apply to all versions of PAS 2.6 and below. 