### PR TITLE
Update Autoscaler CLI docs for PAS

### DIFF
--- a/autoscaler/using-autoscaler-cli.html.md.erb
+++ b/autoscaler/using-autoscaler-cli.html.md.erb
@@ -15,7 +15,7 @@ To install the plugin, do the following:
 
 1. Download the plugin from <a href="https://network.pivotal.io/products/pcf-app-autoscaler">Pivotal Network</a>.
 
-    <p class='note'><strong>Note:</strong> Ensure that you download the App Autoscaler CLI plugin v2.0 or later. In addition, the plugin requires Pivotal Application Service v2.2 or later.</a>.</p> 
+    <p class='note'><strong>Note:</strong> Ensure that you download the App Autoscaler CLI plugin v2.0 or later. In addition, the plugin requires Pivotal Application Service v2.2 or later.</p> 
 
 1. To install the App Autoscaler CLI plugin, run the following command:
 
@@ -28,6 +28,9 @@ To install the plugin, do the following:
     $ cf install-plugin ~/Downloads/autoscaler-for-pcf-cliplugin-macosx64-binary-2.0.91
     </pre> 
     For more information about installing cf CLI plugins, see [Installing a Plugin](../../cf-cli/use-cli-plugins.html#plugin-install). 
+
+## <a id="create-and-bind-service"></a>Create and Bind the Autoscaling Service
+Before you can use the App Autoscaler you need to have created an Autoscaling service and bound that service to your app. See the <a href="https://docs.pivotal.io/pivotalcf/2-6/devguide/services/managing-services.html">Managing Service Instances with the cf CLI</a> topic for more information.
 
 ## <a id="view-apps"></a>View Apps
 
@@ -42,6 +45,16 @@ test-app-2            guid-2          false     10              40
 OK
 </pre>
 
+## <a id="updating-instance-limits"></a>Update Instance Limits
+
+Run `cf update-autoscaling-limits APP-NAME MIN-INSTANCE-LIMIT MAX-INSTANCE-LIMIT` to update the upper and lower app instance limits. The App Autoscaler will not attempt to scale beyond these limits. Replace `APP-NAME` with the name of your app. Replace `MIN-INSTANCE-LIMIT` with the minimum number of apps, and `MAX-INSTANCE-LIMIT` with the maximum number of apps.
+ 
+<pre class="terminal">
+$ cf update-autoscaling-limits test-app 10 40<br>
+Updated autoscaling instance limits for app test-app for org my-org / my-space testing as admin
+OK
+</pre>
+
 ## <a id="enable-autoscaling"></a>Enable Autoscaling
 
 Run `cf enable-autoscaling APP-NAME` to enable autoscaling on your app. Replace `APP-NAME` with the name of your app.
@@ -52,6 +65,8 @@ Enabled autoscaling for app test-app-2 for org my-org / my-space testing as admi
 OK
 </pre>
 
+  <p class='note'><strong>Note:</strong> By default, instance limits are set to <code>Min Instances:-1</code> and <code>Max Instances:-1</code> by default. In order to enable autoscaling, you must first [update instance limits](#updating-instance-limits).</p> 
+
 ## <a id="disable-autoscaling"></a>Disable Autoscaling
 
 Run `cf disable-autoscaling APP-NAME` to disable autoscaling on your app. Replace `APP-NAME` with the name of your app.
@@ -59,16 +74,6 @@ Run `cf disable-autoscaling APP-NAME` to disable autoscaling on your app. Replac
 <pre class="terminal">
 $ cf disable-autoscaling test-app<br>
 Disabled autoscaling for app test-app for org my-org / my-space testing as admin
-OK
-</pre>
-
-## <a id="updating-instance-limits"></a>Update Instance Limits
-
-Run `cf update-autoscaling-limits APP-NAME MIN-INSTANCE-LIMIT MAX-INSTANCE-LIMIT` to update the upper and lower app instance limits. The App Autoscaler will not attempt to scale beyond these limits. Replace `APP-NAME` with the name of your app. Replace `MIN-INSTANCE-LIMIT` with the minimum number of apps, and `MAX-INSTANCE-LIMIT` with the maximum number of apps.
- 
-<pre class="terminal">
-$ cf update-autoscaling-limits test-app 10 40<br>
-Updated autoscaling instance limits for app test-app for org my-org / my-space testing as admin
 OK
 </pre>
 
@@ -135,6 +140,7 @@ For a list of valid types and subtypes, see the following:
 * type `memory`
 * type `http_throughput`
 * type `http_latency`
+  * sub_type `avg_99th` or `avg_95th`
 * type `rabbit-mq`
   * queue_name `YOUR-QUEUE-NAME`
 * type `custom`
@@ -142,6 +148,10 @@ For a list of valid types and subtypes, see the following:
 * type `compare`
   * metric `METRIC-NAME`
   * comparison_metric `METRIC-NAME`
+
+  <p class='note'><strong>Note:</strong> <code>http_latency</code> requires a rule <code>subtype</code> be applied.</p> 
+
+  <p class='note'><strong>Note:</strong> <code>http_latency</code> threshold units are in ms.</p> 
 
 ## <a id="delete-rule"></a>Delete a Rule
 


### PR DESCRIPTION
Made the following changes to the PAS 2.6 docs.
- Indicate percentile is required for latency
- Indicate latency times are in ms
- Note you can't enable a service without first creating a service and binding it
- re-ordere to encourage changing instance limits before enabling autoscaling

These changes will need to be made to docs for all previous versions of PAS, if I could get help with that. 