### PR TITLE
Rebrand PCF Autoscaler

### DIFF
--- a/autoscaler/using-autoscaler.html.md.erb
+++ b/autoscaler/using-autoscaler.html.md.erb
@@ -139,7 +139,7 @@ The table below lists the default metrics for App Autoscaler:
 			Average CPU percentage for all instances of the app.
 		</td>
 		<td>
-			App CPU utilization data may vary greatly based on the number of CPU cores on Diego cells and app density. For more information, see <a href="https://community.pivotal.io/s/article/PCF-Autoscaler-Advisory-for-Scaling-Apps-Based-on-the-CPU-utilization">PCF Autoscaler advisory for scaling Apps based on the CPU utilization</a>.
+			App CPU utilization data may vary greatly based on the number of CPU cores on Diego cells and app density. For more information, see <a href="https://community.pivotal.io/s/article/PCF-Autoscaler-Advisory-for-Scaling-Apps-Based-on-the-CPU-utilization">Pivotal App Autoscaler advisory for scaling Apps based on the CPU utilization</a>.
 		</td>
 	</tr><tr>
 		<td>Container Memory Utilization</td>


### PR DESCRIPTION
Rebrand "PCF Autoscaler" to "Pivotal App Autoscaler"