### PR TITLE
Advise against http_throughput as a scaling metric

### DIFF
--- a/autoscaler/using-autoscaler-cli.html.md.erb
+++ b/autoscaler/using-autoscaler-cli.html.md.erb
@@ -142,7 +142,7 @@ For a list of valid types and subtypes, see the following:
 * type `CPU`
 * type `memory`
 * type `http_throughput`
-  <p class='note'><strong>Note:</strong> It is <a href="https://community.pivotal.io/s/article/autoscaling-using-http-throughput-latency-metrics">not recommended</a> to use <code>http_throughput</code> as a scaling rule when logging volume is high in the system.</p>
+  <p class='note'><strong>Note:</strong> It is <a href="https://community.pivotal.io/s/article/http-throughput-based-autoscaling-rules-do-not-fire">not recommended</a> to use <code>http_throughput</code> as a scaling rule when logging volume is high in the system.</p>
 * type `http_latency`
   * sub\_type `avg_99th` or `avg_95th`
       <p class='note'><strong>Note:</strong> <code>http_latency</code> requires a rule <code>subtype</code>.</p> 

--- a/autoscaler/using-autoscaler-cli.html.md.erb
+++ b/autoscaler/using-autoscaler-cli.html.md.erb
@@ -137,17 +137,18 @@ Guid                                    Type      Metric                        
 
 For a list of valid types and subtypes, see the following:
 
+* type `custom`
+  * metric `METRIC-NAME`
 * type `CPU`
 * type `memory`
 * type `http_throughput`
+  <p class='note'><strong>Note:</strong> It is <a href="https://community.pivotal.io/s/article/autoscaling-using-http-throughput-latency-metrics">not recommended</a> to use <code>http_throughput</code> as a scaling rule when logging volume is high in the system.</p>
 * type `http_latency`
   * sub\_type `avg_99th` or `avg_95th`
       <p class='note'><strong>Note:</strong> <code>http_latency</code> requires a rule <code>subtype</code>.</p> 
       <p class='note'><strong>Note:</strong> <code>http_latency</code> threshold units are in ms.</p> 
 * type `rabbitmq`
   * sub\_type `YOUR-QUEUE-NAME`
-* type `custom`
-  * metric `METRIC-NAME`
 * type `compare`
   * metric `METRIC-NAME`
   * comparison_metric `METRIC-NAME`

--- a/autoscaler/using-autoscaler.html.md.erb
+++ b/autoscaler/using-autoscaler.html.md.erb
@@ -143,7 +143,7 @@ The table below lists the default metrics for App Autoscaler:
 	</tr><tr>
 		<td>HTTP Throughput</td>
 		<td>Total HTTP requests per second (divided by the total number of app instances).</td>
-		<td>It is difficult to determine whether high throughput is evidence of good system performance, or if app performance is poor given the high number of requests. For more information, see <a href="https://community.pivotal.io/s/article/autoscaling-using-http-throughput-latency-metrics">Autoscaling using HTTP Throughput & Latency metrics</a>.</td>
+		<td>It is not recommended to use <code>http_throughput</code> as a scaling rule when logging volume is high in the system. For more information, see <a href="https://community.pivotal.io/s/article/autoscaling-using-http-throughput-latency-metrics">Autoscaling using HTTP Throughput & Latency metrics</a>.</td>
 	</tr><tr>
 		<td>HTTP Latency</td>
 		<td>Average latency of apps response to HTTP requests. This does not include Gorouter processing time or other network latency.<br>

--- a/autoscaler/using-autoscaler.html.md.erb
+++ b/autoscaler/using-autoscaler.html.md.erb
@@ -143,7 +143,7 @@ The table below lists the default metrics for App Autoscaler:
 	</tr><tr>
 		<td>HTTP Throughput</td>
 		<td>Total HTTP requests per second (divided by the total number of app instances).</td>
-		<td>It is not recommended to use <code>http_throughput</code> as a scaling rule when logging volume is high in the system. For more information, see <a href="https://community.pivotal.io/s/article/autoscaling-using-http-throughput-latency-metrics">Autoscaling using HTTP Throughput & Latency metrics</a>.</td>
+		<td>It is not recommended to use <code>http_throughput</code> as a scaling rule when logging volume is high in the system. For more information, see <a href="https://community.pivotal.io/s/article/autoscaling-using-http-throughput-latency-metrics">Autoscaling using HTTP Throughput & Latency metrics</a> and <a href="https://community.pivotal.io/s/article/http-throughput-based-autoscaling-rules-do-not-fire">HTTP throughput based Autoscaling rules do not fire</a>.</td>
 	</tr><tr>
 		<td>HTTP Latency</td>
 		<td>Average latency of apps response to HTTP requests. This does not include Gorouter processing time or other network latency.<br>


### PR DESCRIPTION
- re ordered list of metrics to have custom at top. 
- added note that http_throughput is not recommended at high log volumes.

I'll make a PR to back port this to all relevant versions. 