### PR TITLE
Remove misleading "Ops Manager"

### DIFF
--- a/autoscaler/using-autoscaler.html.md.erb
+++ b/autoscaler/using-autoscaler.html.md.erb
@@ -3,7 +3,7 @@ title: Scaling an App Using App Autoscaler
 owner: App Autoscaler
 ---
 
-This topic describes how <%= vars.platform_name %> users with the Space Developer role can set up and configure the App Autoscaler service in the Apps Manager UI to automatically scale apps based on rules that they set. 
+This topic describes how users with the Space Developer role can set up and configure the App Autoscaler service in the Apps Manager UI to automatically scale apps based on rules that they set. 
 
 You can use the App Autoscaler command-line interface (CLI) plugin to configure App Autoscaler rules from the command line. For more information, see [Using the App Autoscaler CLI](using-autoscaler-cli.html).
 


### PR DESCRIPTION
The "Ops Manager" note is misleading—the user does not need access to Ops Manager to make the changes, only to Apps Manager.

See https://pivotal.slack.com/archives/C268KFDNV/p1597153034117400 for initial request.