### PR TITLE
Don't link to Admin or Operating Guides in TAS offline docs

### DIFF
--- a/autoscaler/custom-metrics.html.md.erb
+++ b/autoscaler/custom-metrics.html.md.erb
@@ -221,7 +221,7 @@ service instance by running:
 
 To configure Autoscaler to use a custom scaling metric for an app using Apps Manager:
 
-1. Log in to Apps Manager. For more information, see [Logging In to Apps Manager](../../operating/console-login.html).
+1. Log in to Apps Manager.<% if not vars.platform_code == 'TAS' %> For more information, see [Logging In to Apps Manager](../../operating/console-login.html). <% end %>
 
 1. Select the org that contains the space in which the app you want to scale is deployed.
 
@@ -282,7 +282,7 @@ To review the autoscaling events that Autoscaler records for changes in the cust
 
 To review the autoscaling events that Autoscaler records for changes in the custom scaling metric for an app through Apps Manager:
 
-1. Log in to Apps Manager. For more information, see [Logging In to Apps Manager](../../operating/console-login.html).
+1. Log in to Apps Manager.<% if not vars.platform_code == 'TAS' %> For more information, see [Logging In to Apps Manager](../../operating/console-login.html).<% end %>
 
 1. Select the org that contains the space in which the app you want to scale is deployed.
 
@@ -339,8 +339,8 @@ want to create a large number of custom scaling metrics, consult the operator of
 ### <a id='log-cache-eviction'></a> Log Cache Eviction
 
 The Metric Registrar scrapes the metrics endpoint on an app and emits the custom scaling metrics it receives. By default, the interval between scrapes is 35
-seconds. You can configure this scrape interval in the **Metric Registrar** pane of the TAS for VMs tile. To configure the scrape interval for the Metric
-Registrar, see [Edit Default Scraping Interval](../../operating/configure-pas.html#scraping-interval) in _Configuring TAS for VMs_.
+seconds. You can configure this scrape interval in the **Metric Registrar** pane of the TAS for VMs tile.<% if not vars.platform_code == 'TAS' %> To configure the scrape interval for the Metric
+Registrar, see [Edit Default Scraping Interval](../../operating/configure-pas.html#scraping-interval) in _Configuring TAS for VMs_. <% end %>
 
 Within Log Cache, each app has its own bucket, which contains both app metrics and logs. By default, Log Cache can hold a maximum of 100,000 envelopes per
 app. Because the platform generates several envelopes per request, and recent app logs are held in the same bucket, a busy app might not have sufficient Log

--- a/autoscaler/http-latency.html.md.erb
+++ b/autoscaler/http-latency.html.md.erb
@@ -34,10 +34,11 @@ for Using HTTP Latency as a Scaling Metric](#special-considerations) below.
 VMware recommends that you load-test your app to verify that the autoscaling rules you configured are effective. For more information, see [Load-Testing Your
 App](productionizing-autoscaler.html#load-testing) in _Using Autoscaler in Production_.
 
+<% if not vars.platform_code == 'TAS' %>
 For more information about the HTTP latency metric, see [Router Handling Latency](../../operating/monitoring/kpi.html#latency) in _Key Performance
 Indicators_. For more information about how TAS for VMs routes HTTP requests, see [TAS for VMs Routing
 Architecture](../../concepts/cf-routing-architecture.html).
-
+<% end %>
 
 ## <a id='cf-cli-config'></a> Configuring HTTP Latency as the Scaling Metric for an App Through the cf CLI
 
@@ -222,7 +223,7 @@ service instance by running:
 
 To configure Autoscaler to use HTTP latency as the scaling metric for an app through Apps Manager:
 
-1. Log in to Apps Manager. For more information, see [Logging In to Apps Manager](../../operating/console-login.html).
+1. Log in to Apps Manager.<% if not vars.platform_code == 'TAS' %> For more information, see [Logging In to Apps Manager](../../operating/console-login.html).<% end %>
 
 1. Select the org that contains the space in which the app you want to scale is deployed.
 
@@ -285,7 +286,7 @@ To review the autoscaling events that Autoscaler records for changes in HTTP lat
 
 To review the autoscaling events that Autoscaler records for changes in HTTP latency through Apps Manager:
 
-1. Log in to Apps Manager. For more information, see [Logging In to Apps Manager](../../operating/console-login.html).
+1. Log in to Apps Manager.<% if not vars.platform_code == 'TAS' %> For more information, see [Logging In to Apps Manager](../../operating/console-login.html).<% end %>
 
 1. Select the org that contains the space in which the app you want to scale is deployed.
 

--- a/autoscaler/observability.html.md.erb
+++ b/autoscaler/observability.html.md.erb
@@ -85,16 +85,16 @@ To view these metrics, see [Review Autoscaler Debug Logs](#review-logs) above.
 You can also use one of the following methods to identify which apps are using Autoscaler:
 
 * You can review the overall number of running app instances that Diego reports for each Diego Cell to measure how many app instances are running at any given
-time. For more information, see [Running App Instances, Rate of Change](../../operating/monitoring/kpi.html#1hraverageofbbs.LRPsRunning) in _Key Performance
-Indicators_.
+time.<% if not vars.platform_code == 'TAS' %> For more information, see [Running App Instances, Rate of Change](../../operating/monitoring/kpi.html#1hraverageofbbs.LRPsRunning) in _Key Performance
+Indicators_.<% end %>
 
 * You can use `cf curl` to retrieve information about Autoscaler service instances from the Cloud Foundry API (CAPI). To identify apps that are using
 Autoscaler through CAPI, see [Retrieve Autoscaler Service Instances from CAPI Endpoints](#capi) below.
 
 Because each team of developers may use different autoscaling rules for their apps, it may be difficult to accurately determine how effectively Autoscaler
 scales each app. However, you can gain a generalized understanding of the effect that Autoscaler has on the apps it scales by comparing the number of running
-app instances with other scaling metrics that the developers of your apps may be using. For more information about various scaling metrics you can use in your
-comparison review, see [Key Performance Indicators](../../operating/monitoring/kpi.html).
+app instances with other scaling metrics that the developers of your apps may be using.<% if not vars.platform_code == 'TAS' %> For more information about various scaling metrics you can use in your
+comparison review, see [Key Performance Indicators](../../operating/monitoring/kpi.html).<% end %>
 
 ### <a id='capi'></a> Retrieve Autoscaler Service Instances from CAPI Endpoints
 

--- a/autoscaler/operating-autoscaler.html.md.erb
+++ b/autoscaler/operating-autoscaler.html.md.erb
@@ -48,8 +48,10 @@ When configuring Autoscaler to scale an app, you must ensure that the resource q
 app within the limits you configure. If the resource quotas that are available for the app to use are lower than the resources required to meet the upper
 scaling limit you configured, Autoscaler cannot scale up to that upper scaling limit.
 
+<% if not vars.platform_code == 'TAS' %>
 For more information about creating and modifying quota plans for your TAS for VMs deployment, see [Creating and Modifying Quota
 Plans](../../adminguide/quota-plans.html).
+<% end %>
 
 ### <a id='platform-capacity'></a> Platform Capacity
 
@@ -186,8 +188,8 @@ To view the number of envelopes that Log Cache stores and the cache duration for
 1. Review the values in the `Count` and `Cache Duration` columns to view the number of envelopes that Log Cache stores and the cache duration for an app.
 
 If necessary, you can increase the maximum number of envelopes that Log Cache can store per app by configuring the **Maximum number of envelopes stored in Log
-Cache per source** field in the **Advanced Features** pane of the TAS for VMs tile. To configure the maximum number of envelopes that Log Cache can store, see
-[Maximum Number of Envelopes Stored in Log Cache Per Source](../../operating/configure-pas.html#log-cache-max-per-source) in _Configuring TAS for VMs_.
+Cache per source** field in the **Advanced Features** pane of the TAS for VMs tile.<% if not vars.platform_code == 'TAS' %> To configure the maximum number of envelopes that Log Cache can store, see
+[Maximum Number of Envelopes Stored in Log Cache Per Source](../../operating/configure-pas.html#log-cache-max-per-source) in _Configuring TAS for VMs_.<% end %>
 
 Additionally, Log Cache may evict envelopes if it has an insufficient amount of memory. To fix this issue, you can scale Log Cache horizontally or vertically.
 To scale Log Cache horizontally or vertically, see [Scaling an App Using cf scale](../../devguide/deploy-apps/cf-scale.html).

--- a/autoscaler/productionizing-autoscaler.html.md.erb
+++ b/autoscaler/productionizing-autoscaler.html.md.erb
@@ -79,8 +79,10 @@ contact the operator for your TAS for VMs deployment.
 When defining resource quotas for a space or org, you must consider not only the scaling needs of an individual app, but the potential scaling needs of other
 apps in the same space or org.
 
+<% if not vars.platform_code == 'TAS' %>
 For more information about creating and modifying quota plans for spaces and orgs, see [Creating and Modifying Quota
 Plans](../../adminguide/quota-plans.html).
+<% end %>
 
 ### <a id='quotas-limiting-scaling'></a> Reviewing Space and Org Quota Plans
 

--- a/autoscaler/rabbit-mq.html.md.erb
+++ b/autoscaler/rabbit-mq.html.md.erb
@@ -222,7 +222,7 @@ service instance by running:
 
 To configure Autoscaler to use RabbitMQ queue depth as the scaling metric for an app using Apps Manager:
 
-1. Log in to Apps Manager. For more information, see [Logging In to Apps Manager](../../operating/console-login.html).
+1. Log in to Apps Manager.<% if not vars.platform_code == 'TAS' %> For more information, see [Logging In to Apps Manager](../../operating/console-login.html).<% end %>
 
 1. Select the org that contains the space in which the app you want to scale is deployed.
 
@@ -327,7 +327,7 @@ To review the autoscaling events that Autoscaler records for changes in RabbitMQ
 
 To review the autoscaling events that Autoscaler records for changes in RabbitMQ queue depth through Apps Manager:
 
-1. Log in to Apps Manager. For more information, see [Logging In to Apps Manager](../../operating/console-login.html).
+1. Log in to Apps Manager.<% if not vars.platform_code == 'TAS' %> For more information, see [Logging In to Apps Manager](../../operating/console-login.html).<% end %>
 
 1. Select the org that contains the space in which the app you want to scale is deployed.
 

--- a/autoscaler/scheduled-limit-changes.html.md.erb
+++ b/autoscaler/scheduled-limit-changes.html.md.erb
@@ -209,7 +209,7 @@ To review the autoscaling events that Autoscaler records for scheduled limit cha
 
 To review the autoscaling events that Autoscaler records for scheduled limit changes through Apps Manager:
 
-1. Log in to Apps Manager. For more information, see [Logging In to Apps Manager](../../operating/console-login.html).
+1. Log in to Apps Manager.<% if not vars.platform_code == 'TAS' %> For more information, see [Logging In to Apps Manager](../../operating/console-login.html).<% end %>
 
 1. Select the org that contains the space in which the app you want to scale is deployed.
 

--- a/autoscaler/spring-tutorial.html.md.erb
+++ b/autoscaler/spring-tutorial.html.md.erb
@@ -51,8 +51,8 @@ Before you begin this tutorial, ensure that you have the following prerequisites
 * A <%= vars.app_runtime_abbr %> deployment in which the Metric Registrar is activated. To configure the Metric Registrar, see [Configure the Metric
 Registrar](../../metric-registrar/index.html#configure) in _Metric Registrar and Custom App Metrics_.
 
-* Access to Apps Manager in the <%= vars.app_runtime_abbr %> deployment. To access Apps Manager, see [Logging In to Apps
-Manager](../../operating/console-login.html).
+* Access to Apps Manager in the <%= vars.app_runtime_abbr %> deployment.<% if not vars.platform_code == 'TAS' %> To access Apps Manager, see [Logging In to Apps
+Manager](../../operating/console-login.html).<% end %>
 
 * The ability to push an app to the <%= vars.app_runtime_abbr %> deployment. For more information, see
 [Prerequisites](../../devguide/deploy-apps/deploy-app.html#prepare) in _Pushing an App_ and [Manage Users and
@@ -261,7 +261,7 @@ Autoscaler is integrated with Apps Manager. You can create autoscaling rules in 
 
 To create an autoscaling rule for the `java-spring-security` app that uses the `custom` metric as its scaling metric:
 
-1. Log in to Apps Manager. For more information, see [Logging In to Apps Manager](../../operating/console-login.html).
+1. Log in to Apps Manager.<% if not vars.platform_code == 'TAS' %> For more information, see [Logging In to Apps Manager](../../operating/console-login.html).<% end %>
 
 1. In Apps Manager, navigate to the `java-spring-security` app overview. For more information, see [View App Overview](../../console/manage-apps.html#view) in
 _Managing Apps and Service Instances Using Apps Manager_.

--- a/autoscaler/troubleshooting.html.md.erb
+++ b/autoscaler/troubleshooting.html.md.erb
@@ -175,8 +175,8 @@ For more information, see the sections below:
 
 To allow autoscaling for an app:
 
-1. Ensure that the **App Autoscaler Errand** is set to **On** in the **Errands** pane of the TAS for VMs tile. To configure the **App Autoscaler Errand** to
-deploy Autoscaler, see [Configure Errands](../../operating/configure-pas.html#errands) in _Configuring TAS for VMs_.
+1. Ensure that the **App Autoscaler Errand** is set to **On** in the **Errands** pane of the TAS for VMs tile.<% if not vars.platform_code == 'TAS' %> To configure the **App Autoscaler Errand** to
+deploy Autoscaler, see [Configure Errands](../../operating/configure-pas.html#errands) in _Configuring TAS for VMs_.<% end %>
 
 1. Configure Autoscaler to scale the app through either the App Autoscaler Command-Line Interface (CLI) or Apps Manager. To configure autoscaling for an app
 through the App Autoscaler CLI, see [Enable Autoscaling](using-autoscaler-cli.html#enable-autoscaling) in _Using the App Autoscaler CLI_. To configure
@@ -208,9 +208,9 @@ To see whether autoscaling is configured for the apps you want to scale:
 Autoscaler may fail to scale an app if one of the TAS for VMs components on which it depends is failing or underscaled. For more information about these
 components, see [Failure Modes](observability.html#failure-modes) in _Using Debug Logs for App Autoscaler_.
 
-These components may need to be restarted or scaled up before Autoscaler can scale your app. To restart TAS for VMs components, see [Stopping and Starting
+These components may need to be restarted or scaled up before Autoscaler can scale your app.<% if not vars.platform_code == 'TAS' %> To restart TAS for VMs components, see [Stopping and Starting
 Individual TAS for VMs VMs](../../adminguide/start-stop-vms.html#manual) in _Stopping and Starting Virtual Machines_. To scale TAS for VMs components up, see
-[Scaling Up TAS for VMs](../../operating/scaling-ert-components.html#scaleup) in _Scaling TAS for VMs_.
+[Scaling Up TAS for VMs](../../operating/scaling-ert-components.html#scaleup) in _Scaling TAS for VMs_.<% end %>
 
 ### <a id='rabbitmq-queue-depth'></a> Autoscaler Fails to Scale Apps Based on RabbitMQ Queue Depth Metric
 
@@ -291,15 +291,15 @@ metrics from its cache.
 
 To fix this issue, you can try the following actions:
 
-* Scale Log Cache horizontally by increasing the number of Log Cache instances in the **Resource Config** pane of the TAS for VMs tile. To scale Log Cache
-horizontally, see [Scaling Up TAS for VMs](../../operating/scaling-ert-components.html#scaleup) in _Scaling TAS for VMs_.
+* Scale Log Cache horizontally by increasing the number of Log Cache instances in the **Resource Config** pane of the TAS for VMs tile.<% if not vars.platform_code == 'TAS' %> To scale Log Cache
+horizontally, see [Scaling Up TAS for VMs](../../operating/scaling-ert-components.html#scaleup) in _Scaling TAS for VMs_.<% end %>
 
 * Scale Log Cache vertically by increasing the amount of memory in each instance of Log Cache. To scale Log Cache vertically, see [Scaling an App Using cf
 scale](../../devguide/deploy-apps/cf-scale.html).
 
 * Increase the maximum number of envelopes that Log Cache can store per app by configuring the **Maximum number of envelopes stored in Log Cache per source**
-field in the **Advanced Features** pane of the TAS for VMs tile. To configure the maximum number of envelopes that Log Cache can store, see [Maximum Number of
-Envelopes Stored in Log Cache Per Source](../../operating/configure-pas.html#log-cache-max-per-source) in _Configuring TAS for VMs_.
+field in the **Advanced Features** pane of the TAS for VMs tile.<% if not vars.platform_code == 'TAS' %> To configure the maximum number of envelopes that Log Cache can store, see [Maximum Number of
+Envelopes Stored in Log Cache Per Source](../../operating/configure-pas.html#log-cache-max-per-source) in _Configuring TAS for VMs_.<% end %>
 
 For more information about how Log Cache supports Autoscaler, see [Log Cache](operating-autoscaler.html#log-cache) in _Operating App Autoscaler_.
 


### PR DESCRIPTION
Authored-by: Ramkumar Vengadakrishnan <ramkumarv@vmware.com>
[#183456407] - [dashboard] Offline Docs red since August