### PR TITLE
Remove misleading autoscaler cf CLI plugin bullet

### DIFF
--- a/autoscaler/using-autoscaler-cli.html.md.erb
+++ b/autoscaler/using-autoscaler-cli.html.md.erb
@@ -289,8 +289,6 @@ To create a new autoscaling rule for an app:
        * <code>memory</code>
        * <code>rabbitmq</code>.
    <ul>
-          <li><%= vars.company_name %> discourages open source. For
-            more information, see <a href="https://community.pivotal.io/s/article/http-throughput-based-autoscaling-rules-do-not-fire">HTTP throughput-based autoscaling rules do not fire</a> in the Knowledge Base.</li>
           <li><code>http_latency</code> threshold units are in milliseconds. In general, the value for <code>MAXIMUM-THRESHOLD</code> must be at least twice the value for <code>MINIMUM-THRESHOLD</code> to avoid excessive cycling. HTTP latency is calculated from the Gorouter to the app and back to the Gorouter. HTTP latency is not calculated between the user and the app.</li>
           <li>If you specify <code>http_latency</code> as the rule type, you must also specify a rule subtype using the <code>--subtype</code> or
             <code>-s</code> parameter.</li>


### PR DESCRIPTION
This looks like a corruption during earlier editing.

Signed-off-by: Andrew Crump <andrew.crump@broadcom.com>
(cherry picked from commit 68adbc2aa8117a459c90c8aa5dc6431e486e78a4)