### PR TITLE
Autoscaler updated rule type names (TAS 5.0)

### DIFF
--- a/autoscaler/about-app-autoscaler.html.md.erb
+++ b/autoscaler/about-app-autoscaler.html.md.erb
@@ -68,32 +68,29 @@ The following table lists the default metrics for App Autoscaler:
   <tr>
     <th>Metric</th>
     <th>Description</th>
-    <th>**Note:**</th>
+    <th>Note</th>
   </tr>
   </thead>
   <tr>
-    <td>CPU Utilization</td>
-    <td>
-      Average CPU percentage for all instances of the app.
-    </td>
-    <td>
-      App CPU utilization data might vary greatly based on the number of CPU cores on Diego Cells and app density. For more information, see <a href="https://community.pivotal.io/s/article/PCF-Autoscaler-Advisory-for-Scaling-Apps-Based-on-the-CPU-utilization">App Autoscaler advisory for scaling Apps based on the CPU utilization</a> in the Knowledge Base.
-    </td>
+    <td>CPU Processor Utilization</td>
+    <td>Average CPU percentage for all instances of the app.</td>
+    <td>App CPU utilization data might vary greatly based on the number of CPU cores on Diego Cells and app density. For more information, see <a href="https://community.pivotal.io/s/article/PCF-Autoscaler-Advisory-for-Scaling-Apps-Based-on-the-CPU-utilization">App Autoscaler advisory for scaling Apps based on the CPU utilization</a> in the Knowledge Base.</td>
   </tr><tr>
     <td>Container Memory Utilization</td>
-    <td>Average memory percentage for all instances of the app.</td>
+    <td>Average memory percentage across all instances of the app.</td>
     <td><em>n/a</em></td>
   </tr><tr>
-    <td>HTTP Throughput</td>
-    <td>Total HTTP requests per second (divided by the total number of app instances).</td>
+    <td>HTTP Request Throughput</td>
+    <td>Average number of HTTP requests per second across all of the app instances.</td>
+    <td><em>n/a</em></td>
   </tr><tr>
-    <td>HTTP Latency</td>
+    <td>HTTP Request Latency</td>
     <td>Average latency of apps response to HTTP requests. This does not include Gorouter processing time or other network latency.<br>
     Average is calculated on the middle 99% or middle 95% of all HTTP requests.</td>
     <td><em>n/a</em></td>
   </tr><tr>
-    <td>RabbitMQ Depth</td>
-    <td>The queue length of the specified queue.</td>
+    <td>RabbitMQ Queue Depth</td>
+    <td>The queue length of the specified RabbitMQ queue.</td>
     <td><em>n/a</em></td>
   </tr>
 </table>

--- a/autoscaler/about-app-autoscaler.html.md.erb
+++ b/autoscaler/about-app-autoscaler.html.md.erb
@@ -42,14 +42,14 @@ The following diagram provides an example of how App Autoscaler makes scaling de
 
 ![alt-text=""](./images/autoscaler-scaling-decisions.png)
 
-As shown in the diagram, an app has a maximum threshold of 200-milliseconds and a minimum threshold of 80-milliseconds for an HTTP latency metric. The scale up factor and
+As shown in the diagram, an app has a maximum threshold of 200-milliseconds and a minimum threshold of 80-milliseconds for an HTTP Request Latency metric. The scale up factor and
 scale down factor are not set in the scaling manifest, so the default value is one.
 
-If HTTP latency averages 220-milliseconds for 120-seconds, App Autoscaler scales the app up one instance.
+If HTTP Request Latency averages 220-milliseconds for 120-seconds, App Autoscaler scales the app up one instance.
 
-If HTTP latency then averages 70-milliseconds over the next 120-second window and the app's other scaling metrics also fall below their minimum thresholds, App Autoscaler scales the app down one instance.
+If HTTP Request Latency then averages 70-milliseconds over the next 120-second window and the app's other scaling metrics also fall below their minimum thresholds, App Autoscaler scales the app down one instance.
 
-If the average value for HTTP latency over a 120-second window falls below the maximum threshold of 200-milliseconds or the minimum threshold of 80-milliseconds, App Autoscaler maintains the same number of instances for the app.
+If the average value for HTTP Request Latency over a 120-second window falls below the maximum threshold of 200-milliseconds or the minimum threshold of 80-milliseconds, App Autoscaler maintains the same number of instances for the app.
 
 You can set a maximum and minimum number of instances. For example, if an app exceeds the maximum threshold of selected metric, but the number of
 instances is already at the maximum number of instances, App Autoscaler does not scale up the app.

--- a/autoscaler/about-app-autoscaler.html.md.erb
+++ b/autoscaler/about-app-autoscaler.html.md.erb
@@ -22,7 +22,7 @@ For example, you might configure App Autoscaler to scale down the number of inst
 
 This section describes how the App Autoscaler decides when to scale an app up or down.
 
-It also provides information about the custom metrics, comparison metrics, and default metrics that you can use when you create scaling rules for an app in App Autoscaler.
+It also provides information about the Custom App Metrics, comparison metrics, and default metrics that you can use when you create scaling rules for an app in App Autoscaler.
 
 ### <a id="about-scaling-decisions"></a> How App Autoscaler decides when to scale
 
@@ -59,7 +59,7 @@ instances is already at the maximum number of instances, App Autoscaler does not
 App Autoscaler includes several default metrics for which you might create scaling rules.
 
 <p class="note">
-<span class="note__title">Note</span><%= vars.company_name %> recommends that you define custom metrics for scaling rules instead of using the default metrics. You can use Custom metrics to accurately monitor the performance of your apps based on your environment.</p>
+<span class="note__title">Note</span><%= vars.company_name %> recommends that you define Custom App Metrics for scaling rules instead of using the default metrics. You can use Custom App Metrics to accurately monitor the performance of your apps based on your environment.</p>
 
 The following table lists the default metrics for App Autoscaler:
 
@@ -95,15 +95,15 @@ The following table lists the default metrics for App Autoscaler:
   </tr>
 </table>
 
-### <a id="custom-metrics"></a> Custom metrics for scaling rules
+### <a id="custom-metrics"></a> Custom App Metrics for scaling rules
 
-<%= vars.company_name %> recommends that you define custom metrics for App Autoscaler scaling rules. You can use custom metrics define the metrics that are the best indicators of app performance for your environment.
+<%= vars.company_name %> recommends that you define Custom App Metrics for App Autoscaler scaling rules. You can use Custom App Metrics to define the metrics that are the best indicators of app performance for your environment.
 
-You can configure apps to emit custom metrics out of the Loggregator Firehose using Metric Registrar. For steps on how to configure your apps to emit custom metrics with Metric Registrar, see [Registering custom app metrics](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/4.0/tas-for-vms/metric-registrar-index.html).
+You can configure apps to emit Custom App Metrics out of the Loggregator Firehose using Metric Registrar. For steps on how to configure your apps to emit Custom App Metrics with Metric Registrar, see [Registering custom app metrics](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/4.0/tas-for-vms/metric-registrar-index.html).
 
 ### <a id="comparison-metrics"></a> Comparison metrics for scaling rules
 
-You can use the **Comparison Metric** text box in App Autoscaler to define a scaling rule that divides one custom metric by another.
+You can use the **Comparison Metric** text box in App Autoscaler to define a scaling rule that divides one Custom App Metric by another.
 
 When you add a scaling rule, the **Metric** text box is the dividend and the **Comparison Metric** text box is the divisor.
 

--- a/autoscaler/about-app-autoscaler.html.md.erb
+++ b/autoscaler/about-app-autoscaler.html.md.erb
@@ -22,7 +22,7 @@ For example, you might configure App Autoscaler to scale down the number of inst
 
 This section describes how the App Autoscaler decides when to scale an app up or down.
 
-It also provides information about the Custom App Metrics, comparison metrics, and default metrics that you can use when you create scaling rules for an app in App Autoscaler.
+It also provides information about the Custom App Metrics, Custom App Metric Ratios, and default metrics that you can use when you create scaling rules for an app in App Autoscaler.
 
 ### <a id="about-scaling-decisions"></a> How App Autoscaler decides when to scale
 
@@ -63,7 +63,7 @@ App Autoscaler includes several default metrics for which you might create scali
 
 The following table lists the default metrics for App Autoscaler:
 
-<table class="table" >
+<table class="table">
 <thead>
   <tr>
     <th>Metric</th>
@@ -101,9 +101,9 @@ The following table lists the default metrics for App Autoscaler:
 
 You can configure apps to emit Custom App Metrics out of the Loggregator Firehose using Metric Registrar. For steps on how to configure your apps to emit Custom App Metrics with Metric Registrar, see [Registering custom app metrics](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/4.0/tas-for-vms/metric-registrar-index.html).
 
-### <a id="comparison-metrics"></a> Comparison metrics for scaling rules
+### <a id="comparison-metrics"></a> Custom App Metric Ratios
 
-You can use the **Comparison Metric** text box in App Autoscaler to define a scaling rule that divides one Custom App Metric by another.
+You can use the **Comparison Metric** text box in Apps Manager to define a scaling rule that divides one Custom App Metric by another.
 
 When you add a scaling rule, the **Metric** text box is the dividend and the **Comparison Metric** text box is the divisor.
 

--- a/autoscaler/custom-metrics.html.md.erb
+++ b/autoscaler/custom-metrics.html.md.erb
@@ -3,14 +3,14 @@ title: Configure App Autoscaler to use custom scaling metrics
 owner: Autoscaler
 ---
 
-You can configure App Autoscaler to use custom metrics when scaling apps in your VMware TAS for VMs deployment.
+You can configure App Autoscaler to use Custom App Metrics when scaling apps in your VMware TAS for VMs deployment.
 
-For information about how to emit custom metrics, see [Using Metric Registrar](../../metric-registrar/using.html).
+For information about how to emit Custom App Metrics, see [Using Metric Registrar](../../metric-registrar/using.html).
 
 
 ## <a id='overview'></a> Custom scaling metrics overview
 
-While Autoscaler can use several default metrics as scaling metrics for apps, your app might require specific autoscaling requirements that Autoscaler cannot meet by using the default scaling metrics to scale the app. In this case, you might create custom metrics for Autoscaler to use to scale the app.
+While Autoscaler can use several default metrics as scaling metrics for apps, your app might require specific autoscaling requirements that Autoscaler cannot meet by using the default scaling metrics to scale the app. In this case, you might create Custom App Metrics for Autoscaler to use to scale the app.
 
 Before configuring Autoscaler to use a custom scaling metric, you must register the metrics endpoint of the app with the
 Metric Registrar. For more information, see [Using Metric Registrar](../../metric-registrar/using.html).
@@ -343,6 +343,6 @@ Configuring an app to emit a large number of custom scaling metrics might cause 
 The Metric Registrar scrapes the metrics endpoint on an app and emits the custom scaling metrics it receives. By default, the interval between scrapes is 35
 seconds. You can configure this scrape interval in the **Metric Registrar** pane of the TAS for VMs tile.<% if vars.platform_code != 'OFFLINE' %> To configure the scrape interval for the Metric Registrar, see [Edit Default Scraping Interval](../../operating/configure-pas.html#scraping-interval) in _Configuring TAS for VMs_. <% end %>
 
-Within Log Cache, each app has its own bucket, which contains both app metrics and logs. By default, Log Cache can hold a maximum of 100,000 envelopes per app. Because the platform generates several envelopes per request, and recent app logs are held in the same bucket, a busy app might not have sufficient Log Cache custom metric history for Autoscaler to use in scaling decisions.
+Within Log Cache, each app has its own bucket, which contains both app metrics and logs. By default, Log Cache can hold a maximum of 100,000 envelopes per app. Because the platform generates several envelopes per request, and recent app logs are held in the same bucket, a busy app might not have sufficient Log Cache Custom App Metric history for Autoscaler to use in scaling decisions.
 
 For more information, see [Log Cache](operating-autoscaler.html#log-cache) in _Operating App Autoscaler_.

--- a/autoscaler/custom-metrics.html.md.erb
+++ b/autoscaler/custom-metrics.html.md.erb
@@ -332,7 +332,7 @@ Autoscaler cannot use counter metrics as custom scaling metrics. If you register
 
 ### <a id='metric-labels'></a> Metric labels
 
-Autoscaler does not differentiate between metrics based on labels. If the metrics endpoint features the same metric with different labels, such as HTTP latency metrics with labels that describe the endpoint from which they came, Autoscaler does not recognize the labels.
+Autoscaler does not differentiate between metrics based on labels. If the metrics endpoint features the same metric with different labels, such as HTTP Request Latency metrics with labels that describe the endpoint from which they came, Autoscaler does not recognize the labels.
 
 ### <a id='high-metric-load'></a> High metric load
 

--- a/autoscaler/http-latency.html.md.erb
+++ b/autoscaler/http-latency.html.md.erb
@@ -117,19 +117,19 @@ following configuration parameters:
     </ul>
 
     The following example shows an Autoscaler manifest file with a percentile of 95%, a minimum HTTP Request Latency threshold of 125 milliseconds, and a maximum HTTP
-    latency threshold of 250 milliseconds:
+    Request Latency threshold of 250 milliseconds:
 
     ```
     ---
     instance_limits:
-      min: LOWER-SCALING-LIMIT
-      max: UPPER-SCALING-LIMIT
+      min: 10
+      max: 100
     rules:
     - rule_type: http_latency
-      rule_sub_type: PERCENTILE
+      rule_sub_type: avg_95th
       threshold:
-        min: MINIMUM-LATENCY-THRESHOLD
-        max: MAXIMUM-LATENCY-THRESHOLD
+        min: 125
+        max: 250
     scheduled_limit_changes: []
     ```
 
@@ -253,7 +253,7 @@ To configure Autoscaler to use HTTP Request Latency as the scaling metric for an
 
    1. For **Scale up if more than**, enter in milliseconds the maximum HTTP Request Latency threshold you want to configure. If the average latency of HTTP requests rises above this number, Autoscaler scales the number of app instances up. To avoid excessive cycling, VMware recommends that you configure a maximum threshold that is at least twice the value of the minimum threshold.
 
-   2. Under **Percent of traffic to apply**, select either **95%** or **99%**. This configuration setting is the percentile that Autoscaler uses in scaling decisions. Depending on which option you select, Autoscaler ignores HTTP requests that fall outside either the 95th or 99th percentile and averages the latency of the remaining 95% or 99% of HTTP requests.
+   1. Under **Percent of traffic to apply**, select either **95%** or **99%**. This configuration setting is the percentile that Autoscaler uses in scaling decisions. Depending on which option you select, Autoscaler ignores HTTP requests that fall outside either the 95th or 99th percentile and averages the latency of the remaining 95% or 99% of HTTP requests.
 
 1. Click **Save**.
 
@@ -329,7 +329,7 @@ If your app relies on back-end HTTP services that apps in your TAS for VMs deplo
 
 ### <a id='log-cache-eviction'></a> Log cache ejection
 
-Autoscaler retrieves HTTP metrics from Log Cache, which mmight hold a maximum of 100,000 envelopes per app by default. If your app receives a large number of HTTP requests or is configured to create very verbose logs, Log Cache might drop some of the timer envelopes that it holds. If Autoscaler can only retrieve some of the total timer envelopes it requires to calculate accurate metrics, then the HTTP Request Latency metric might inaccurately represent the actual HTTP Request Latency of the app or causes of decreased app performance. However, in most cases, the HTTP Request Latency metric still approximates the actual HTTP Request Latency of the app.
+Autoscaler retrieves HTTP metrics from Log Cache, which might hold a maximum of 100,000 envelopes per app by default. If your app receives a large number of HTTP requests or is configured to create very verbose logs, Log Cache might drop some of the timer envelopes that it holds. If Autoscaler can only retrieve some of the total timer envelopes it requires to calculate accurate metrics, then the HTTP Request Latency metric might inaccurately represent the actual HTTP Request Latency of the app or causes of decreased app performance. However, in most cases, the HTTP Request Latency metric still approximates the actual HTTP Request Latency of the app.
 
 For more information, see [Log cache](operating-autoscaler.html#log-cache) in _Operating App Autoscaler_.
 

--- a/autoscaler/http-latency.html.md.erb
+++ b/autoscaler/http-latency.html.md.erb
@@ -1,39 +1,39 @@
 ---
-title: Use HTTP latency as a scaling metric with App Autoscaler
+title: Use HTTP Request Latency as a scaling metric with App Autoscaler
 owner: Autoscaler
 ---
 
-You can configure App Autoscaler to use the HTTP latency metric to scale apps in your VMware TAS for VMs deployment.
+You can configure App Autoscaler to use the HTTP Request Latency metric to scale apps in your VMware TAS for VMs deployment.
 
 
-## <a id='overview'></a> HTTP latency overview
+## <a id='overview'></a> HTTP Request Latency Overview
 
-When an HTTP request is made to an app, the Gorouter in VMware Tanzu Application Service for VMs (TAS for VMs) generates several metrics. One of these metrics is `gorouter.latency`, or _HTTP latency_. The HTTP latency metric measures the length of time it takes to process an HTTP request, starting from when the Gorouter receives a request and ending when the Gorouter completes processing the response from the app. This metric includes the length of time it takes all back-end endpoints to respond, including other apps and TAS for VMs components such as Cloud Controller and UAA. Long uploads, downloads, or app responses increase the time.
+When an HTTP request is made to an app, the Gorouter in VMware Tanzu Application Service for VMs (TAS for VMs) generates several metrics. One of these metrics is `gorouter.latency`, or _HTTP Request Latency_. The HTTP Request Latency metric measures the length of time it takes to process an HTTP request, starting from when the Gorouter receives a request and ending when the Gorouter completes processing the response from the app. This metric includes the length of time it takes all back-end endpoints to respond, including other apps and TAS for VMs components such as Cloud Controller and UAA. Long uploads, downloads, or app responses increase the time.
 
-For example, you might have a Service Level Agreement (SLA) specifying that 95% of requests for an app must be processed in less than 300-milliseconds. To help achieve this, you can configure an autoscaling rule for Autoscaler to create additional instances of the app when the HTTP latency metric reaches 250 milliseconds.
+For example, you might have a Service Level Agreement (SLA) specifying that 95% of requests for an app must be processed in less than 300-milliseconds. To help achieve this, you can configure an autoscaling rule for Autoscaler to create additional instances of the app when the HTTP Request Latency metric reaches 250 milliseconds.
 
-You can configure Autoscaler to use HTTP latency as the scaling metric for an app in the following ways:
+You can configure Autoscaler to use HTTP Request Latency as the scaling metric for an app in the following ways:
 
-* Through the Cloud Foundry Command-Line Interface (cf CLI). For more information, see [Configuring HTTP latency as the scaling metric for an app through the cf CLI](#cf-cli-config).
+* Through the Cloud Foundry Command-Line Interface (cf CLI). For more information, see [Configuring HTTP Request Latency as the scaling metric for an app through the cf CLI](#cf-cli-config).
 
-* Through Apps Manager. For more information, see [Configure HTTP latency as the scaling metric for an app through Apps Manager](#apps-manager-config).
+* Through Apps Manager. For more information, see [Configure HTTP Request Latency as the scaling metric for an app through Apps Manager](#apps-manager-config).
 
-To monitor when Autoscaler scales an app based on changes in HTTP latency, see [Reviewing autoscaling events for changes in HTTP latency](#review-events).
+To monitor when Autoscaler scales an app based on changes in HTTP Request Latency, see [Reviewing autoscaling events for changes in HTTP Request Latency](#review-events).
 
-For information about use cases that might complicate or prevent you from configuring HTTP latency as the scaling metric for an app, see [Special considerations for using HTTP latency as a scaling metric](#special-considerations).
+For information about use cases that might complicate or prevent you from configuring HTTP Request Latency as the scaling metric for an app, see [Special considerations for using HTTP Request Latency as a scaling metric](#special-considerations).
 
 VMware recommends that you load-test your app to verify that the autoscaling rules you configured are effective. For more information, see [Load-testing your app](productionizing-autoscaler.html#load-testing) in _Using Autoscaler in Production_.
 
 <% if vars.platform_code != 'OFFLINE' %>
-For more information about the HTTP latency metric, see [Router handling latency](../../operating/monitoring/kpi.html#latency) in _Key Performance Indicators_. For more information about how TAS for VMs routes HTTP requests, see [TAS for VMs routing architecture](../../concepts/cf-routing-architecture.html).
+For more information about the HTTP Request Latency metric, see [Router handling latency](../../operating/monitoring/kpi.html#latency) in _Key Performance Indicators_. For more information about how TAS for VMs routes HTTP requests, see [TAS for VMs routing architecture](../../concepts/cf-routing-architecture.html).
 <% end %>
 
 
-## <a id='cf-cli-config'></a> Configure HTTP latency as the scaling metric for an app through the cf CLI
+## <a id='cf-cli-config'></a> Configure HTTP Request Latency as the scaling metric for an app through the cf CLI
 
-The procedures in this section describe how to configure Autoscaler to use HTTP latency as the scaling metric for an app through the cf CLI.
+The procedures in this section describe how to configure Autoscaler to use HTTP Request Latency as the scaling metric for an app through the cf CLI.
 
-You can configure configure Autoscaler to use HTTP latency as the scaling metric for an app in the following ways:
+You can configure configure Autoscaler to use HTTP Request Latency as the scaling metric for an app in the following ways:
 
 * Using a manifest file. For more information, see [Configure an autoscaling rule using a manifest file](#cf-cli-manifest-config).
 
@@ -45,7 +45,7 @@ For the procedures in this section, you must use the App Autoscaler CLI plug-in.
 
 You can configure autoscaling rules declaratively through a manifest file. This manifest file only configures Autoscaler, and does not interfere with any other existing app manifest files in your TAS for VMs deployment.
 
-To configure an autoscaling rule that defines HTTP latency as its scaling metric using a manifest file:
+To configure an autoscaling rule that defines HTTP Request Latency as its scaling metric using a manifest file:
 
 1. In a terminal window, target the space in which the app you want to scale is deployed by running:
 
@@ -86,7 +86,7 @@ Autoscaler service instance by running:
       <li><code>SERVICE-INSTANCE-NAME</code> is the name of the Autoscaler service instance in the previous step.</li>
     </ul>
 
-1. To create a manifest file for Autoscaler that configures an autoscaling rule with HTTP latency as its scaling metric, create a YAML file that includes the
+1. To create a manifest file for Autoscaler that configures an autoscaling rule with HTTP Request Latency as its scaling metric, create a YAML file that includes the
 following configuration parameters:
 
     ```
@@ -109,14 +109,14 @@ following configuration parameters:
       <li><code>UPPER-SCALING-LIMIT</code> is the maximum number of instances you want Autoscaler to create for the app.</li>
       <li><code>PERCENTILE</code> is the percentile that Autoscaler uses in scaling decisions. Valid values are <code>avg_95th</code> or <code>avg_99th</code>. This value configures Autoscaler to
       ignore HTTP requests that fall outside either the 95th or 99th percentile and average the latency of the remaining 95% or 99% of HTTP requests.</li>
-      <li><code>MINIMUM-LATENCY-THRESHOLD</code> is the minimum HTTP latency threshold in milliseconds. If the average latency of HTTP requests falls below this number,
+      <li><code>MINIMUM-LATENCY-THRESHOLD</code> is the minimum HTTP Request Latency threshold in milliseconds. If the average latency of HTTP requests falls below this number,
       Autoscaler scales the number of app instances down.</li>
-      <li><code>MAXIMUM-LATENCY-THRESHOLD</code> is the maximum HTTP latency threshold in milliseconds. If the average latency of HTTP requests rises above this number,
+      <li><code>MAXIMUM-LATENCY-THRESHOLD</code> is the maximum HTTP Request Latency threshold in milliseconds. If the average latency of HTTP requests rises above this number,
       Autoscaler scales the number of app instances up. To avoid excessive cycling, VMware recommends that you configure a maximum threshold that is at least
       twice the value of the minimum threshold.</li>
     </ul>
 
-    The following example shows an Autoscaler manifest file with a percentile of 95%, a minimum HTTP latency threshold of 125 milliseconds, and a maximum HTTP
+    The following example shows an Autoscaler manifest file with a percentile of 95%, a minimum HTTP Request Latency threshold of 125 milliseconds, and a maximum HTTP
     latency threshold of 250 milliseconds:
 
     ```
@@ -148,7 +148,7 @@ following configuration parameters:
 
 ### <a id='cf-cli-commands-config'></a> Configure an autoscaling rule by using CLI commands
 
-To configure an autoscaling rule that defines HTTP latency as its scaling metric using CLI commands:
+To configure an autoscaling rule that defines HTTP Request Latency as its scaling metric using CLI commands:
 
 1. In a terminal window, target the space in which the app you want to scale is deployed by running:
 
@@ -218,22 +218,22 @@ service instance by running:
     Where:
     <ul>
       <li><code>APP-NAME</code> is the name of the app for which you want to create an autoscaling rule.</li>
-      <li><code>MINIMUM-LATENCY-THRESHOLD</code> is the minimum HTTP latency threshold in milliseconds. If the average latency of HTTP requests falls below this number, Autoscaler scales the number of app instances down.</li>
-      <li><code>MAXIMUM-LATENCY-THRESHOLD</code> is the maximum HTTP latency threshold in milliseconds. If the average latency of HTTP requests rises above this number, Autoscaler scales the number of app instances up. To avoid excessive cycling, VMware recommends that you configure a maximum threshold that is at least twice the value of the minimum threshold.</li>
+      <li><code>MINIMUM-LATENCY-THRESHOLD</code> is the minimum HTTP Request Latency threshold in milliseconds. If the average latency of HTTP requests falls below this number, Autoscaler scales the number of app instances down.</li>
+      <li><code>MAXIMUM-LATENCY-THRESHOLD</code> is the maximum HTTP Request Latency threshold in milliseconds. If the average latency of HTTP requests rises above this number, Autoscaler scales the number of app instances up. To avoid excessive cycling, VMware recommends that you configure a maximum threshold that is at least twice the value of the minimum threshold.</li>
       <li><code>PERCENTILE</code> is the percentile that Autoscaler uses in scaling decisions. Valid values are <code>avg_95th</code> or <code>avg_99th</code>. This value configures Autoscaler to ignore HTTP requests that fall outside either the 95th or 99th percentile and average the latency of the remaining 95% or 99% of HTTP requests.</li>
     </ul>
 
-    The following example command configures an `http_latency` autoscaling rule for the `example-app` app, with a minimum HTTP latency threshold of 125-milliseconds,
-    a maximum HTTP latency threshold of 250-milliseconds, and a percentile of 95%:
+    The following example command configures an `http_latency` autoscaling rule for the `example-app` app, with a minimum HTTP Request Latency threshold of 125-milliseconds,
+    a maximum HTTP Request Latency threshold of 250-milliseconds, and a percentile of 95%:
 
     ```
     cf create-autoscaling-rule example-app http_latency 125 250 --subtype avg_95th
     ```
 
 
-## <a id='apps-manager-config'></a> Configure HTTP latency as the scaling metric for an app through Apps Manager
+## <a id='apps-manager-config'></a> Configure HTTP Request Latency as the scaling metric for an app through Apps Manager
 
-To configure Autoscaler to use HTTP latency as the scaling metric for an app through Apps Manager:
+To configure Autoscaler to use HTTP Request Latency as the scaling metric for an app through Apps Manager:
 
 1. Log in to Apps Manager.<% if vars.platform_code != 'OFFLINE' %> For more information, see [Logging in to Apps Manager](../../operating/console-login.html).<% end %>
 
@@ -247,30 +247,30 @@ To configure Autoscaler to use HTTP latency as the scaling metric for an app thr
 
 1. Click **Add rule**. The **Select type** drop-down menu appears.
 
-2. From the **Select type** drop-down menu, select **HTTP Latency**.
+2. From the **Select type** drop-down menu, select **HTTP Request Latency**.
 
-   1. For **Scale down if less than**, enter in milliseconds the minimum HTTP latency threshold you want to configure. If the average latency of HTTP requests falls below this number, Autoscaler scales the number of app instances down.
+   1. For **Scale down if less than**, enter in milliseconds the minimum HTTP Request Latency threshold you want to configure. If the average latency of HTTP requests falls below this number, Autoscaler scales the number of app instances down.
 
-   1. For **Scale up if more than**, enter in milliseconds the maximum HTTP latency threshold you want to configure. If the average latency of HTTP requests rises above this number, Autoscaler scales the number of app instances up. To avoid excessive cycling, VMware recommends that you configure a maximum threshold that is at least twice the value of the minimum threshold.
+   1. For **Scale up if more than**, enter in milliseconds the maximum HTTP Request Latency threshold you want to configure. If the average latency of HTTP requests rises above this number, Autoscaler scales the number of app instances up. To avoid excessive cycling, VMware recommends that you configure a maximum threshold that is at least twice the value of the minimum threshold.
 
    2. Under **Percent of traffic to apply**, select either **95%** or **99%**. This configuration setting is the percentile that Autoscaler uses in scaling decisions. Depending on which option you select, Autoscaler ignores HTTP requests that fall outside either the 95th or 99th percentile and averages the latency of the remaining 95% or 99% of HTTP requests.
 
 1. Click **Save**.
 
 
-## <a id='review-events'></a> Reviewing autoscaling events for changes in HTTP latency
+## <a id='review-events'></a> Reviewing autoscaling events for changes in HTTP Request Latency
 
-When Autoscaler scales the number of app instances up after the HTTP latency metric increases above the maximum HTTP latency threshold, Autoscaler records an autoscaling event.
+When Autoscaler scales the number of app instances up after the HTTP Request Latency metric increases above the maximum HTTP Request Latency threshold, Autoscaler records an autoscaling event.
 
-You can monitor the autoscaling events that Autoscaler records for changes in HTTP latency in the following ways:
+You can monitor the autoscaling events that Autoscaler records for changes in HTTP Request Latency in the following ways:
 
-* Through the cf CLI. See [Review autoscaling events for changes in HTTP latency through the cf CLI](#review-events-cli).
+* Through the cf CLI. See [Review autoscaling events for changes in HTTP Request Latency through the cf CLI](#review-events-cli).
 
-* Through Apps Manager. See [Review autoscaling events for changes in HTTP latency through Apps Manager](#review-events-apps-manager).
+* Through Apps Manager. See [Review autoscaling events for changes in HTTP Request Latency through Apps Manager](#review-events-apps-manager).
 
-### <a id='review-events-cli'></a> Review autoscaling events for changes in HTTP latency through the cf CLI
+### <a id='review-events-cli'></a> Review autoscaling events for changes in HTTP Request Latency through the cf CLI
 
-To review the autoscaling events that Autoscaler records for changes in HTTP latency through the cf CLI:
+To review the autoscaling events that Autoscaler records for changes in HTTP Request Latency through the cf CLI:
 
 1. In a terminal window, run:
 
@@ -280,16 +280,16 @@ To review the autoscaling events that Autoscaler records for changes in HTTP lat
     Where `APP-NAME` is the name of the app for which you want to review autoscaling events.
     <br>
     <br>
-    If Autoscaler has scaled the number of app instances up due to increases in the HTTP latency metric, the above command returns output that contains
+    If Autoscaler has scaled the number of app instances up due to increases in the HTTP Request Latency metric, the above command returns output that contains
     autoscaling events similar to the following example:
     <pre class="terminal">
     Time                   Description
     2022-05-23T21:47:45Z   Scaled up from 10 to 11 instances. Current HTTP Latency of 1010.96ms is above upper threshold of 250.00ms.
     </pre>
 
-### <a id='review-latency-events'></a> Review autoscaling events for changes in HTTP latency through Apps Manager
+### <a id='review-latency-events'></a> Review autoscaling events for changes in HTTP Request Latency through Apps Manager
 
-To review the autoscaling events that Autoscaler records for changes in HTTP latency through Apps Manager:
+To review the autoscaling events that Autoscaler records for changes in HTTP Request Latency through Apps Manager:
 
 1. Log in to Apps Manager.<% if vars.platform_code != 'OFFLINE' %> For more information, see [Logging in to Apps Manager](../../operating/console-login.html).<% end %>
 
@@ -299,42 +299,42 @@ To review the autoscaling events that Autoscaler records for changes in HTTP lat
 
 1. Under **Under Processes and Instances**, click **Manage Autoscaling**.
 
-1. Under **Event History**, click **View More**. A list of autoscaling events appears. If Autoscaler has scaled the number of app instances up due to increases in the HTTP latency metric, the list of autoscaling events includes events similar to the following example:
+1. Under **Event History**, click **View More**. A list of autoscaling events appears. If Autoscaler has scaled the number of app instances up due to increases in the HTTP Request Latency metric, the list of autoscaling events includes events similar to the following example:
 
     ```
     Scaled up from 10 to 11 instances. Current HTTP Latency of 1010.96ms is above upper threshold of 250.00ms.
     ```
 
 
-## <a id='special-considerations'></a> Special considerations for using HTTP latency as a scaling metric
+## <a id='special-considerations'></a> Special considerations for using HTTP Request Latency as a scaling metric
 
-This section describes use cases that might complicate or prevent you from configuring HTTP latency as the scaling metric for an app.
+This section describes use cases that might complicate or prevent you from configuring HTTP Request Latency as the scaling metric for an app.
 
 ### <a id='multiple-endpoints'></a> Multiple endpoints
 
-In an app that exposes multiple endpoints, the value of the HTTP latency metric is the average HTTP latency across all app endpoints. If one or more endpoints process requests at a slower rate than the others, HTTP latency might not be an ideal scaling metric to use. Even a fast endpoint might cause the average HTTP latency to increase if it receives a large number of requests.
+In an app that exposes multiple endpoints, the value of the HTTP Request Latency metric is the average HTTP Request Latency across all app endpoints. If one or more endpoints process requests at a slower rate than the others, HTTP Request Latency might not be an ideal scaling metric to use. Even a fast endpoint might cause the average HTTP Request Latency to increase if it receives a large number of requests.
 
 ### <a id='external-factors'></a> External factors
 
-Components or services that receive data from an app are known as _downstream_ components. If any downstream components respond slowly to requests from an app, they might cause HTTP latency to increase. In this case, scaling the app up does not improve its performance. In fact, scaling the app up might _increase_ HTTP latency, because requests from the additional app instances add a greater burden on the downstream component. The downstream component must be scaled up or improved before scaling the app up might improve its performance.
+Components or services that receive data from an app are known as _downstream_ components. If any downstream components respond slowly to requests from an app, they might cause HTTP Request Latency to increase. In this case, scaling the app up does not improve its performance. In fact, scaling the app up might _increase_ HTTP Request Latency, because requests from the additional app instances add a greater burden on the downstream component. The downstream component must be scaled up or improved before scaling the app up might improve its performance.
 
-Other external factors, such as network congestion or database performance, can also cause HTTP latency to increase. In this case, scaling the app does not decrease HTTP latency that results from these external factors.
+Other external factors, such as network congestion or database performance, can also cause HTTP Request Latency to increase. In this case, scaling the app does not decrease HTTP Request Latency that results from these external factors.
 
 ### <a id='c2c'></a> Container-to-container networking
 
-Autoscaler can only use HTTP latency as a scaling metric for apps that receive requests directly through the Gorouter. Autoscaler does not support
-using HTTP latency as a scaling metric for apps that receive requests from other apps through container-to-container (C2C) networking or TCP routers.
+Autoscaler can only use HTTP Request Latency as a scaling metric for apps that receive requests directly through the Gorouter. Autoscaler does not support
+using HTTP Request Latency as a scaling metric for apps that receive requests from other apps through container-to-container (C2C) networking or TCP routers.
 
 If your app relies on back-end HTTP services that apps in your TAS for VMs deployment must access through C2C networking, the Gorouter does not generate HTTP events for those requests. As a result, Autoscaler cannot scale those HTTP services. For Autoscaler to scale them, you must either use a different default scaling metric or create a custom scaling metric for them.
 
 ### <a id='log-cache-eviction'></a> Log cache ejection
 
-Autoscaler retrieves HTTP metrics from Log Cache, which mmight hold a maximum of 100,000 envelopes per app by default. If your app receives a large number of HTTP requests or is configured to create very verbose logs, Log Cache might drop some of the timer envelopes that it holds. If Autoscaler can only retrieve some of the total timer envelopes it requires to calculate accurate metrics, then the HTTP latency metric might inaccurately represent the actual HTTP latency of the app or causes of decreased app performance. However, in most cases, the HTTP latency metric still approximates the actual HTTP latency of the app.
+Autoscaler retrieves HTTP metrics from Log Cache, which mmight hold a maximum of 100,000 envelopes per app by default. If your app receives a large number of HTTP requests or is configured to create very verbose logs, Log Cache might drop some of the timer envelopes that it holds. If Autoscaler can only retrieve some of the total timer envelopes it requires to calculate accurate metrics, then the HTTP Request Latency metric might inaccurately represent the actual HTTP Request Latency of the app or causes of decreased app performance. However, in most cases, the HTTP Request Latency metric still approximates the actual HTTP Request Latency of the app.
 
 For more information, see [Log cache](operating-autoscaler.html#log-cache) in _Operating App Autoscaler_.
 
 ### <a id='infrequent-requests'></a> Infrequent requests
 
-If an app receives requests infrequently and responds slowly, Autoscaler might continue scaling the app up because there are no other HTTP latency metrics to restore the average. In this case, Autoscaler usually stops scaling the app up after the original request falls outside of the metric collection interval.
+If an app receives requests infrequently and responds slowly, Autoscaler might continue scaling the app up because there are no other HTTP Request Latency metrics to restore the average. In this case, Autoscaler usually stops scaling the app up after the original request falls outside of the metric collection interval.
 
 For more information about how Autoscaler's metric collection interval affects its scaling decisions, see [How App Autoscaler decides when to scale](about-app-autoscaler.html#about-scaling-decisions) in _About App Autoscaler_.

--- a/autoscaler/productionizing-autoscaler.html.md.erb
+++ b/autoscaler/productionizing-autoscaler.html.md.erb
@@ -117,7 +117,7 @@ To define autoscaling rules for Autoscaler, see:
 For more information about the scaling metrics you can use when defining autoscaling rules for Autoscaler, see:
 
 * [Default metrics for scaling rules](about-app-autoscaler.html#default-metrics)
-* [Custom metrics for scaling rules](about-app-autoscaler.html#custom-metrics) in _About App Autoscaler_.
+* [Custom App Metrics for scaling rules](about-app-autoscaler.html#custom-metrics) in _About App Autoscaler_.
 
 ### <a id='c2c-networking'></a> Autoscaler and C2C networking
 

--- a/autoscaler/productionizing-autoscaler.html.md.erb
+++ b/autoscaler/productionizing-autoscaler.html.md.erb
@@ -92,11 +92,11 @@ Interface (cf CLI). For more information about app manifests, see [App manifest 
 
 You can define rules for Autoscaler to scale your app instances up or down using a particular scaling metric.
 
-Initially, VMware recommends that you define a single autoscaling rule using a scaling metric such as **HTTP Latency** or **RabbitMQ Queue Depth**. At a later time, it might be appropriate to define more than one autoscaling rule for the same app.
+Initially, VMware recommends that you define a single autoscaling rule using a scaling metric such as **HTTP Request Latency** or **RabbitMQ Queue Depth**. At a later time, it might be appropriate to define more than one autoscaling rule for the same app.
 
-Thesee are two of the default scaling metrics you can select when you define an autoscaling rule for an app:
+These are two of the default scaling metrics you can select when you define an autoscaling rule for an app:
 
-* **HTTP Latency:** Use this scaling metric if your app receives HTTP requests directly from the Gorouter, and you want to scale the number of app instances up as the average latency of the requests increases. Before choosing this metric as your scaling metric, consider whether scaling your app might increase HTTP latency. If additional app instances must use the same external resource, such as a MySQL service instance or another app, this might increase HTTP latency. If Autoscaler scales the number of app instances up, and HTTP latency is still over the maximum metric threshold you configured because all app instances rely on the same external resource, Autoscaler continues to create more app instances to no effect.
+* **HTTP Request Latency:** Use this scaling metric if your app receives HTTP requests directly from the Gorouter, and you want to scale the number of app instances up as the average latency of the requests increases. Before choosing this metric as your scaling metric, consider whether scaling your app might increase HTTP Request Latency. If additional app instances must use the same external resource, such as a MySQL service instance or another app, this might increase HTTP Request Latency. If Autoscaler scales the number of app instances up, and HTTP Request Latency is still over the maximum metric threshold you configured because all app instances rely on the same external resource, Autoscaler continues to create more app instances to no effect.
 
 * **RabbitMQ Queue Depth:** Use this scaling metric if your app reads messages from a RabbitMQ queue, and you want to scale the number of app instances up to read messages from the RabbitMQ queue more quickly.
 
@@ -121,7 +121,7 @@ For more information about the scaling metrics you can use when defining autosca
 
 ### <a id='c2c-networking'></a> Autoscaler and C2C networking
 
-Autoscaler can only use **HTTP Latency** and **HTTP Throughput** as a scaling metric for apps that receive requests directly through the Gorouter. Autoscaler does not support using these two metrics for apps that receive requests from other apps through container-to-container (C2C) networking or TCP routers.
+Autoscaler can only use **HTTP Request Latency** and **HTTP Request Throughput** as a scaling metric for apps that receive requests directly through the Gorouter. Autoscaler does not support using these two metrics for apps that receive requests from other apps through container-to-container (C2C) networking or TCP routers.
 
 If your app relies on back-end HTTP services that apps in your TAS for VMs deployment must access through C2C networking, the Gorouter does not generate HTTP events for those requests. As a result, Autoscaler cannot scale those HTTP services. For Autoscaler to scale them, you must either use a different default scaling metric or create a custom scaling metric for them.
 
@@ -130,7 +130,7 @@ If your app relies on back-end HTTP services that apps in your TAS for VMs deplo
 
 You can define scale-up and scale-down factors to control how quickly Autoscaler scales app instances in each direction. For example, when you configure an app with a scale-up factor of `20` and a scale-down factor of `10`, Autoscaler scales the number of app instances up by 20 instances at a time and down by 10 instances at a time.
 
-When you define a larger scale-up factor for an app, Autoscaler scales the number of app instances up more quickly in response to the scaling metric you defined reaching its maximum metric threshold. Because of this, using a particular scaling metric for the app might cause or exacerbate performance issues for the app in some circumstances. If networking issues or an unresponsive downstream service causes greater HTTP latency, configuring Autoscaler to scale app instances up by a larger number might cause HTTP latency to worsen even more.
+When you define a larger scale-up factor for an app, Autoscaler scales the number of app instances up more quickly in response to the scaling metric you defined reaching its maximum metric threshold. Because of this, using a particular scaling metric for the app might cause or exacerbate performance issues for the app in some circumstances. If networking issues or an unresponsive downstream service causes greater HTTP Request Latency, configuring Autoscaler to scale app instances up by a larger number might cause HTTP Request Latency to worsen even more.
 
 In many production deployments, the scale-down factor for an app is lower than the scale-up factor. This helps an app to scale up, then return to an earlier baseline number of instances more slowly by stepping down in smaller increments. You might want to configure a lower scale-down factor if you do not want Autoscaler to scale the number of app instances down too quickly, and you are less concerned about freeing up resources.
 
@@ -170,7 +170,7 @@ The next sections provide more information about load testing to confirm the eff
 
 ### <a id='generate-load'></a> Generating load and monitoring scaling events
 
-There are a variety of tools you can use for load-testing. The method that you use for generating load varies based on both the load-testing tool you use and the scaling metric that you define for the app, because you must generate load that causes the scaling metric to fluctuate. For example, you might generate HTTP requests for apps that use HTTP latency as their scaling metric, or you might generate RabbitMQ messages for apps that use RabbitMQ queue depth as their scaling metric.
+There are a variety of tools you can use for load-testing. The method that you use for generating load varies based on both the load-testing tool you use and the scaling metric that you define for the app, because you must generate load that causes the scaling metric to fluctuate. For example, you might generate HTTP requests for apps that use HTTP Request Latency as their scaling metric, or you might generate RabbitMQ messages for apps that use RabbitMQ queue depth as their scaling metric.
 
 VMware recommends incrementally increasing the load you generate for an app. With each increase, you can see whether Autoscaler is scaling the number of app instances as expected by monitoring the autoscaling events that Autoscaler records.
 

--- a/autoscaler/spring-tutorial.html.md.erb
+++ b/autoscaler/spring-tutorial.html.md.erb
@@ -94,7 +94,7 @@ See the [ExampleController.java](https://github.com/pivotal-cf/metric-registrar-
             customGauge.decrementAndGet();
         }
 	```
-The App Autoscaler only scales on a gauge, or metric, that can go up and down. The standard metrics of CPU, disk, HTTP throughput, and HTTP latency are all gauges.
+The App Autoscaler only scales on a gauge, or metric, that can go up and down. The standard metrics of CPU Processor Utilization, Container Memory Utilization, HTTP Request Throughput, and HTTP Request Latency are all gauges.
 
 
 ## <a id="push"></a> Push the sample app

--- a/autoscaler/spring-tutorial.html.md.erb
+++ b/autoscaler/spring-tutorial.html.md.erb
@@ -1,11 +1,11 @@
 ---
-title: Tutorial Scaling a Spring App on a custom metric
+title: Tutorial Scaling a Spring App on a Custom App Metric
 owner: Autoscaler
 ---
 
-You can scale an app with Autoscaler in your <%= vars.app_runtime_abbr %> deployment based on a custom metric.
+You can scale an app with Autoscaler in your <%= vars.app_runtime_abbr %> deployment based on a Custom App Metric.
 
-In a <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) deployment, Autoscaler can scale apps based on custom metrics.
+In a <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) deployment, Autoscaler can scale apps based on Custom App Metrics.
 The table describes the main components involved in this workflow and how they correspond to steps in this tutorial.
 
 <table class="table">
@@ -18,13 +18,13 @@ The table describes the main components involved in this workflow and how they c
 	</thead>
 	<tr>
 		<td>App</td>
-		<td>The app must emit custom metrics by exposing a Prometheus endpoint. This tutorial includes a sample Spring app, <code>java-spring-security</code>, that emits such metrics. For more information about Prometheus, see the <a href="https://prometheus.io/docs/introduction/overview/#what-is-prometheus">Prometheus documentation</a>.</td>
+		<td>The app must emit Custom App Metrics by exposing a Prometheus endpoint. This tutorial includes a sample Spring app, <code>java-spring-security</code>, that emits such metrics. For more information about Prometheus, see the <a href="https://prometheus.io/docs/introduction/overview/#what-is-prometheus">Prometheus documentation</a>.</td>
 		<td><a href="#review">Review the sample spp</a> and <a href="#push">Push the sample app</a></td>
 	</tr>
 	<tr>
 		<td>Metric Registrar</td>
 		<td>The Metric Registrar is a component of <%= vars.app_runtime_abbr %> you can export custom app metrics to Loggregator. You issue commands to the Metric Registrar through the Metric Registrar CLI plug-in. For more information about the Metric Registrar, see <a href="../../metric-registrar/index.html">Metric registrar and custom app metrics</a>.</td>
-		<td><a href="#register-endpoint">Register a custom metrics endpoint</a></td>
+		<td><a href="#register-endpoint">Register a Custom App Metrics endpoint</a></td>
 	</tr>
 	<tr>
 		<td>App Autoscaler</td>
@@ -152,11 +152,11 @@ To push the sample app:
   * **Increment Simple counter** and **Call an endpoint with high latency:** These buttons are not used in this tutorial. To learn about these functions, see [java-spring-security](https://github.com/pivotal-cf/metric-registrar-examples/tree/master/java-spring-security) on GitHub.
 
 
-## <a id="register-endpoint"></a> Register a custom metrics endpoint
+## <a id="register-endpoint"></a> Register a Custom App Metrics endpoint
 
-When you want to your app to emit custom metrics, you register the app as a metric source with the Metric Registrar.
+When you want to your app to emit Custom App Metrics, you register the app as a metric source with the Metric Registrar.
 
-To register a custom metrics endpoint for the app:
+To register a Custom App Metrics endpoint for the app:
 
 1. Install the Metric Registrar CLI:
 
@@ -238,16 +238,16 @@ To create an autoscaling rule for the `java-spring-security` app that uses the `
 
 ## <a id="trigger"></a> Trigger scaling
 
-Now that you pushed an app that emits a custom metric and configured autoscaling rules, you can trigger a scaling action. App Autoscaler scales the app when the custom metric goes above or below the threshold specified in the scaling rule.
+Now that you pushed an app that emits a Custom App Metric and configured autoscaling rules, you can trigger a scaling action. App Autoscaler scales the app when the Custom App Metric goes above or below the threshold specified in the scaling rule.
 
 To trigger scaling:
 
 1. Navigate to the web UI of the app. Use the same URL from [Push the sample app](#push).
 
-1. Click **Increment Custom gauge** enough times to bring the custom metric  over the threshold of `5` that you set in the scaling rule. You can see the value of the `custom` metric using the **See Metrics** button.
+1. Click **Increment Custom gauge** enough times to bring the Custom App Metric  over the threshold of `5` that you set in the scaling rule. You can see the value of the `custom` metric using the **See Metrics** button.
 
 1. Monitor the app page in Apps Manager for about two minutes. App Autoscaler begins to scale the app. It adds one instance at a time until it reaches the **Maximum** instance limit of `5`.
 
 ## <a id="next-steps"></a> Next steps
 
-Now that you completed this tutorial, explore the app emitting custom metrics and creating scaling rules with your own app. Review the resources listed in the Overview section to learn more. After you instrument your app to emit custom metrics, you can follow the steps outlined in this tutorial to scale based on those metrics.
+Now that you completed this tutorial, explore the app emitting Custom App Metrics and creating scaling rules with your own app. Review the resources listed in the Overview section to learn more. After you instrument your app to emit Custom App Metrics, you can follow the steps outlined in this tutorial to scale based on those metrics.

--- a/autoscaler/troubleshooting.html.md.erb
+++ b/autoscaler/troubleshooting.html.md.erb
@@ -292,7 +292,7 @@ Because other scaling metrics are not emitted when an app has zero instances, Au
 
 ## <a id='slow-response'></a> New app instances are slow to respond to requests
 
-When Autoscaler scales an app up, the new app instances can be slow to respond to requests. As a result, if you configure Autoscaler to use HTTP latency as the scaling metric for the app, Autoscaler might scale the number of app instances up even more to compensate for the slow response time of the app instances it had previously created.
+When Autoscaler scales an app up, the new app instances can be slow to respond to requests. As a result, if you configure Autoscaler to use HTTP Request Latency as the scaling metric for the app, Autoscaler might scale the number of app instances up even more to compensate for the slow response time of the app instances it had previously created.
 
 When a new app instance is created, Diego runs health checks for the app instance. After all health checks are complete, Diego considers the app instance to be healthy. Diego then registers a route to the app instance with the Gorouter, and the Gorouter begins routing requests to the app instance.
 

--- a/autoscaler/troubleshooting.html.md.erb
+++ b/autoscaler/troubleshooting.html.md.erb
@@ -199,7 +199,7 @@ Cloud Controller. However, when a TAS for VMs deployment is configured to store 
 
 If the operator of your deployment has selected **Yes** under **On Demand - Secure Service Instance Credentials with Runtime CredHub** in the **Global Settings for On-Demand Plans** pane of the VMware Tanzu RabbitMQ for VMs tile and selected the **Secure service instance credentials** check box in the **CredHub** pane of the TAS for VMs tile, Autoscaler is unable to use RabbitMQ queue depth as the scaling metric for apps bound to RabbitMQ service instances.
 
-As a workaround, you can configure your app to emit a custom metric containing the RabbitMQ queue depth and configure Autoscaler to use this metric as its scaling metric for the app. For more information about custom metrics, see [Using custom scaling metrics](custom-metrics.html).
+As a workaround, you can configure your app to emit a Custom App Metric containing the RabbitMQ queue depth and configure Autoscaler to use this metric as its scaling metric for the app. For more information about Custom App Metrics, see [Using custom scaling metrics](custom-metrics.html).
 
 
 ## <a id='underscaling'></a> Autoscaler does not scale an app to expected number of instances

--- a/autoscaler/using-autoscaler-api.html.md.erb
+++ b/autoscaler/using-autoscaler-api.html.md.erb
@@ -10,7 +10,7 @@ See [Using the App Autoscaler CLI](using-autoscaler-cli.html).
 
 ## <a id="api-endpoints"></a>API endpoints
 
-The API uses the autoscale-api app that runs next to the autoscale app in the autoscaling space of the system org.
+The API is exposed by the autoscale-api app that runs next to the autoscale app in the autoscaling space of the system org.
 This is the base URL of all the requests covered in the following sections.
 
 If your system domain is `system-domain.com`, in most cases you can reach the autoscale app at `autoscale.sys.system-domain.com` and the API at `autoscale.sys.system-domain.com/api/v2`.

--- a/autoscaler/using-autoscaler-cli.html.md.erb
+++ b/autoscaler/using-autoscaler-cli.html.md.erb
@@ -284,8 +284,8 @@ To create a new autoscaling rule for an app:
       <span class="note__title">Note</span>
           <ul>
               <li><code>http_latency</code> threshold units are in milliseconds. In general, the value for <code>MAXIMUM-THRESHOLD</code> should be at least twice
-              the value for <code>MINIMUM-THRESHOLD</code> to avoid excessive cycling. HTTP latency is calculated from the Gorouter to the app and back to the
-              Gorouter. HTTP latency is not calculated between the user and the app.</li>
+              the value for <code>MINIMUM-THRESHOLD</code> to avoid excessive cycling. HTTP Request Latency is calculated from the Gorouter to the app and back to the
+              Gorouter. HTTP Request Latency is not calculated between the user and the app.</li>
               <li>If you specify <code>http_latency</code> as the rule type, you must also specify a rule subtype using the <code>--subtype</code> or <code>-s</code> parameter.</li>
               <li>If you specify <code>compare</code> as the rule type, you must also specify a scaling metric using the <code>--metric</code> or <code>-m</code>
               parameter and a comparison metric using the <code>--comparison-metric</code> or <code>-c</code> parameter.</li>
@@ -310,7 +310,7 @@ To create a new autoscaling rule for an app:
 
 See also:
 
-* For information about configuring Autoscaler to use HTTP latency as the scaling metric for an app, see [Using HTTP latency as a scaling metric](http-latency.html).
+* For information about configuring Autoscaler to use HTTP Request Latency as the scaling metric for an app, see [Using HTTP Request Latency as a scaling metric](http-latency.html).
 
 * For information about configuring Autoscaler to use RabbitMQ queue depth as the scaling metric for an app, see [Using RabbitMQ queue depth as a scaling metric](rabbit-mq.html).
 
@@ -521,7 +521,7 @@ To configure Autoscaler using a manifest file:
       <li><code>UPPER-SCALING-LIMIT</code> is the maximum number of instances that you want Autoscaler to create for the app by default.</li>
       <li>(Optional) If you include a <code>rules</code> block:
         <ul>
-          <li><code>RULE-TYPE</code> is the type of autoscaling rule you want Autoscaler to use for autoscaling decisions. For more information about configuring autoscaling rules using a manifest file, see <a href="http-latency.html">Using HTTP latency as a scaling metric</a>, <a href="rabbit-mq.html">Using RabbitMQ queue depth as a scaling metric</a>, and <a href="custom-metrics.html">Using custom scaling metrics</a>.</li>
+          <li><code>RULE-TYPE</code> is the type of autoscaling rule you want Autoscaler to use for autoscaling decisions. For more information about configuring autoscaling rules using a manifest file, see <a href="http-latency.html">Using HTTP Request Latency as a scaling metric</a>, <a href="rabbit-mq.html">Using RabbitMQ queue depth as a scaling metric</a>, and <a href="custom-metrics.html">Using custom scaling metrics</a>.</li>
         </ul>
       </li>
       <li><code>MINIMUM-METRIC-THRESHOLD</code> is the minimum scaling metric threshold. If the average value of the scaling metric falls below this number, Autoscaler scales the number of app instances down.</li>

--- a/autoscaler/using-autoscaler-cli.html.md.erb
+++ b/autoscaler/using-autoscaler-cli.html.md.erb
@@ -231,13 +231,7 @@ For more information about scaling factors, see [Scaling factors](productionizin
 
 ## <a id='autoscaling-rules'></a> Autoscaling rules and scaling metrics
 
-Using the procedures in this section, you can configure autoscaling rules for Autoscaler to use when making scaling decisions for an app.
-
-See also:
-
-* For information about scaling metrics for which you can configure autoscaling rules, see [Scaling metrics](productionizing-autoscaler.html#scaling-metrics) in _Using App Autoscaler in Production_.
-
-* For information about the scaling metrics you can use when defining autoscaling rules for Autoscaler, see [Default metrics for scaling rules](about-app-autoscaler.html#default-metrics) and [Custom metrics for scaling rules](about-app-autoscaler.html#custom-metrics) in _About App Autoscaler_.
+For information about the scaling metrics you can use when defining autoscaling rules for Autoscaler, see [Default metrics for scaling rules](about-app-autoscaler.html#default-metrics) and [Custom App Metrics for scaling rules](about-app-autoscaler.html#custom-metrics) in _About App Autoscaler_.
 
 ### <a id='view-rules'></a> View all autoscaling rules
 

--- a/autoscaler/using-autoscaler.html.md.erb
+++ b/autoscaler/using-autoscaler.html.md.erb
@@ -117,10 +117,10 @@ To add a scaling rule for an app:
 1. Set the minimum and maximum thresholds for the metric. For information about setting instance limits, see [About App Autoscaler scaling rules](about-app-autoscaler.html#about-scaling) in _About App Autoscaler_.
 
 2. Select or fill in any other text boxes that appear under the threshold text boxes:
-    * If you are adding an **HTTP Latency** rule, configure **Percent of traffic to apply**.
-    * If you are adding a **RabbitMQ** depth rule, provide the name of the queue to measure.
-    * If you are adding a **Custom** rule, enter your custom **Metric**.
-    * If you are adding a **Compare** rule, enter values in the **Metric** and **Comparison Metric** text boxes.
+    * If you are adding an **HTTP Request Latency** rule, configure **Percent of traffic to apply**.
+    * If you are adding a **RabbitMQ Queue Depth** depth rule, provide the name of the queue to measure.
+    * If you are adding a **Custom App Metric** rule, enter your custom **Metric**.
+    * If you are adding a **Custom App Metric Ratio** rule, enter values in the **Metric** and **Comparison Metric** text boxes.
 
 3. Click **Save**.
 


### PR DESCRIPTION
* Updates to the Autoscaler rule type names to reflect new names in Apps Manager to show in newer TAS patches.
* Backported from #116 
* @fifthposition I'm not sure it makes sense to try and have the docs reflect both the old and new names as it will be potentially more confusing