### PR TITLE
Update download urls for Broadcom

### DIFF
--- a/autoscaler/troubleshooting.html.md.erb
+++ b/autoscaler/troubleshooting.html.md.erb
@@ -342,4 +342,4 @@ error:
 
 <pre class="terminal">Error: Invalid AutoScaler API endpoint</pre>
 
-You must instead use the VMware Tanzu App Autoscaler CLI Plug-in. To download the VMware Tanzu App Autoscaler CLI plug-in, go to [Tanzu Network](https://network.tanzu.vmware.com/products/pcf-app-autoscaler/).
+You must instead use the VMware Tanzu App Autoscaler CLI Plug-in. To download the VMware Tanzu App Autoscaler CLI plug-in, go to [<%= vars.product_network %>](https://support.broadcom.com/group/ecx/productdownloads?subfamily=Pivotal%20App%20Autoscaler%20CLI%20Plugin).

--- a/autoscaler/using-autoscaler-cli.html.md.erb
+++ b/autoscaler/using-autoscaler-cli.html.md.erb
@@ -21,7 +21,7 @@ Before running App Autoscaler CLI commands, you must install the App Autoscaler 
 
 To install the plug-in:
 
-1. Download the [Tanzu App Autoscaler CLI plug-in](https://network.tanzu.vmware.com/products/pcf-app-autoscaler/) from <%= vars.product_network %>.
+1. Download the [Tanzu App Autoscaler CLI plug-in](https://support.broadcom.com/group/ecx/productdownloads?subfamily=Pivotal%20App%20Autoscaler%20CLI%20Plugin) from <%= vars.product_network %>.
 
   <p class="note important">
   <span class="note__title">Important</span>


### PR DESCRIPTION
- Update urls to go to broadcom customer support portal. Unfortunately the link only redirects to a login page.
- Update one instance of Tanzu Network to vars.product_network